### PR TITLE
Fixed Factory/Label conflict

### DIFF
--- a/param/Label.cpp
+++ b/param/Label.cpp
@@ -143,7 +143,7 @@ namespace Util
          }
       }
       if (label.input_ == label.string_) {
-         Label::input_.clear();;
+         Label::input_.clear();
          Label::isClear_ = true;
          Label::isMatched_ = true;
       } else {

--- a/param/Label.h
+++ b/param/Label.h
@@ -11,7 +11,6 @@
 #include <util/global.h>
 #include <iostream>
 #include <string>
-#include <string>
 
 namespace Util
 {
@@ -175,6 +174,18 @@ namespace Util
 
       friend std::istream& operator >> (std::istream& in, Label label);
       friend std::ostream& operator << (std::ostream& out, Label label);
+
+      /*
+      * The default behavior of Label is that, to read a string from
+      * the parameter file, the expected label string must match the
+      * input string. However, if a polymorphic block is being read
+      * (which is processed by the Factory class), we do not know the
+      * expected label string beforehand, and thus need to be able to
+      * override the default behavior of Label. So, we make Factory a
+      * friend of Label so it can access the private member variable
+      * input_, which is not accessible to any other classes. 
+      */
+      template <typename Data> friend class Factory;
 
    };
 

--- a/param/MatrixParam.tpp
+++ b/param/MatrixParam.tpp
@@ -27,7 +27,7 @@ namespace Util
       name_(label),
       lBracket_("["),
       rBracket_("]"),
-      m_(n),
+      m_(m),
       n_(n),
       isRequired_(isRequired),
       hasBrackets_(false)


### PR DESCRIPTION
This pull request fixes a conflict that I encountered between the Factory class and the Label class. 

The issue occurred while reading a parameter file. The two lines of code that created the issue are given below:
```
readParamCompositeOptional(in, wall());
iteratorPtr_ = iteratorFactoryPtr_->readObject(in, *this, className, isEnd);
```
I was attempting to read an optional paramComposite, followed by reading a polymorphic object by calling `Factory::readObject()`. If the optional paramComposite was omitted from the param file, then the code broke.

Here I explain why the code broke. Most objects are read by the Label class. The expected name of the object is stored in `Label::string`, and then the text that is read from the param file is stored in `Label::input_`. If the two members of Label match, then we create the object. If they don't match, then we throw an error (if the object was required) or move on to the next object we wish to read (if the object was optional). In the latter case, we will update `Label::string` and again check if it matches `Label::input_`, because `Label::input_` contains whatever was on the next line of the param file and we can't proceed in the param file until it is matched.

The problem arises when `Label::input_` contains an unmatched string and we attempt to read a polymorphic object (via `Factory::readObject`). The Factory doesn't actually know the expected string beforehand, so we can't just update `Label::string` and expect it to match `Label::input_`. Instead, Factory was implemented so that it read its input directly from the param file and then used the string to identify the object that it should create. However, `Factory::readObject()` was reading directly from the param file even if the string that it was looking for was already stored in `Label::input_`. This meant that it was reading the next item in the param file which was not the actual string that it was looking for, so the Factory could not successfully read the object it was meant to read.

To solve this, I made a relatively simple change: make Factory a friend of Label. This way, Factory can see what is stored in `Label::input_` (even though this member is private), allowing it to find the correct string regardless of whether it is stored in `Label::input_` or is the next item in the param file. This essentially overrides the default behavior of Label in the case of a polymorphic block, which seems reasonable given that Label was designed to read objects with names that are known in advance (which is not true of a polymorphic block).