### PR TITLE
Allow optional polymorphic blocks to be read by Factory

### DIFF
--- a/param/Label.h
+++ b/param/Label.h
@@ -29,6 +29,12 @@ namespace Util
    * Exception. If the input value does not match and isRequired is false,
    * the >> operator stores the input value in a string buffer, and will 
    * compare it to subsequent values until a match is found.
+   * 
+   * Generally, the string that is read from the file should not be
+   * directly accessed by any outside class; the >> operator should be
+   * used to handle the input string. However, several static member 
+   * functions are provided to bypass this default behavior if needed
+   * (clear, setIsMatched, read, and buffer).
    *
    * \ingroup Param_Module
    */
@@ -43,9 +49,7 @@ namespace Util
       static const int LabelWidth  = 20;
 
       /**
-      * Reset buffer and flags to initial state.
-      * 
-      * Clears buffer, sets isClear = true and isMatched = false.
+      * Clears buffer and sets isClear = true.
       */
       static void clear();
 
@@ -55,14 +59,32 @@ namespace Util
       static bool isClear();
 
       /**
+      * Manually set isMatched_.
+      * 
+      * \param isMatched Boolean to store in isMatched_.
+      */
+      static void setIsMatched(bool isMatched);
+
+      /**
       * Did the most recent attempt to match a Label succeed?
       *
-      * Returns true after a succesful match by operator >>
+      * Returns true after a successful match by operator >>
       * or the match() function. Returns false before any 
       * attempt to match any Label, after a failed attempt 
       * with an an optional label.
       */
       static bool isMatched();
+
+      /**
+      * Extract string from input stream and store in the buffer without 
+      * attempting to match. If matching is desired, use >> operator.
+      */
+      static void read(std::istream& in);
+
+      /** 
+      * Get a copy of the string that is currently stored in the buffer.
+      */ 
+      static std::string buffer();
 
       // Non-static Public Members
 
@@ -153,7 +175,7 @@ namespace Util
    // Static members:
 
       /**
-      * Is the Label::input_ buffer clear? (initialized true).
+      * Is Label::buffer_ clear? (initialized true).
       */
       static bool isClear_;
 
@@ -168,24 +190,12 @@ namespace Util
       static bool isMatched_;
 
       /// Most recent input value from istream (initialized empty).
-      static std::string input_;
+      static std::string buffer_;
 
    //friends:
 
       friend std::istream& operator >> (std::istream& in, Label label);
       friend std::ostream& operator << (std::ostream& out, Label label);
-
-      /*
-      * The default behavior of Label is that, to read a string from
-      * the parameter file, the expected label string must match the
-      * input string. However, if a polymorphic block is being read
-      * (which is processed by the Factory class), we do not know the
-      * expected label string beforehand, and thus need to be able to
-      * override the default behavior of Label. So, we make Factory a
-      * friend of Label so it can access the private member variable
-      * input_, which is not accessible to any other classes. 
-      */
-      template <typename Data> friend class Factory;
 
    };
 
@@ -216,10 +226,29 @@ namespace Util
    {  return isRequired_; }
 
    /*
-   * Did the most recent attempt to read match?
+   * Is the input buffer clear? (static member function).
+   */
+   inline bool Label::isClear()
+   {  return isClear_; }
+
+   /*
+   * Did the most recent attempt to read match? 
+   * (static member function)
    */
    inline bool Label::isMatched()
    {  return isMatched_; }
+
+   /*
+   * Manually set isMatched. (static member function)
+   */
+   inline void Label::setIsMatched(bool isMatched)
+   {  isMatched_ = isMatched; }
+
+   /*
+   * Get the string that is currently stored in the buffer.
+   */ 
+   inline std::string Label::buffer()
+   {  return buffer_; }
 
 } 
 #endif

--- a/tests/param/serial/LabelTest.h
+++ b/tests/param/serial/LabelTest.h
@@ -139,6 +139,26 @@ public:
       std::cout << "\n"; 
    }
 
+   void testRead()
+   {
+      printMethod(TEST_FUNC);
+      std::ifstream in;
+      openInputFile("in/Label", in);
+      Label::read(in);
+      Label::setIsMatched(false);
+      TEST_ASSERT(Label::isMatched() == false);
+      TEST_ASSERT(Label::buffer() == "MyLabel");
+
+      Label::read(in); // should do nothing, buffer not clear
+
+      // Make label object and use >> operator. This will not
+      // read a new string since buffer is not clear, but it
+      // will perform string matching tests
+      Label label("MyLabel", true);
+      in >> label; 
+      TEST_ASSERT(Label::isMatched());
+   }
+
 };
 
 
@@ -151,6 +171,7 @@ TEST_ADD(LabelTest, testExtractor2)
 TEST_ADD(LabelTest, testExtractor3)
 #endif
 TEST_ADD(LabelTest, testInserter)
+TEST_ADD(LabelTest, testRead)
 TEST_END(LabelTest)
 
 #endif


### PR DESCRIPTION
This pull request modifies Factory and Label to allow for ***optional*** polymorphic blocks to be read by Factory. Until now, a block could be polymorphic (read by Factory) or optional (read by paramComposite) but not both.

This is implemented primarily by giving Label a few new static member functions that make it slightly less opaque to other classes. There is now a static member function `buffer()` that gives read access to the string that is stored in the "buffer" variable, which is the string that has been read from the file. Another new static function `setIsMatched()` allows other classes to manually change the isMatched_ variable. A third new static function `read()` allows the Label class to read from an input stream into the buffer variable without performing string-matching checks, and without actually creating a Label object. 

With these changes to Label, the method `Factory::readObject()` is able to read a string from the param file using the Label class static functions, rather than reading the string directly from the input stream. This better emulates the way that the Label class is used to read non-polymorphic objects, so that polymorphic objects can be read as either optional or required parameters just like non-polymorphic objects.

To this end, a new optional input variable `isRequired` is added to `readObject()`, which indicates whether the polymorphic object is required or optional. This parameter is true by default. Because it is an optional variable, this pull request maintains backwards compatibility with software that uses the old version of util, which would call `readObject()` without including `isRequired`. 

A new member function is added to the Factory class as well, called `readObjectOptional()`, which calls `readObject()` with `isRequired` set to false.

All unit tests in util and pscfpp passed after making these changes (including the new unit test that I added for the `Label::read()` function). Additionally, I checked whether `Factory::readObjectOptional()` works properly by testing it on the Sweep factory in pscfpp – I removed the `hasSweep` input from `pspc::System::readParameters`, and instead used `readObjectOptional` to read the sweep object, and it was successful!