### PR TITLE
Fixed handling of "}" in Factory::readObject

### DIFF
--- a/param/Factory.h
+++ b/param/Factory.h
@@ -284,11 +284,15 @@ namespace Util
       length = Label::buffer().size();
 
       // If Label::buffer() = '}', set isEnd=true and return null ptr.
+      // Clear the Label if this object isRequired, otherwise leave 
+      // the "}" in Label::buffer().
       if (length == 1 && Label::buffer()[0] == '}') {
          className = std::string();
          isEnd = true;
-         Label::clear();
-         Label::setIsMatched(true);
+         if (isRequired) {
+            Label::clear();
+            Label::setIsMatched(true);
+         }
          return 0; 
       } else {
          isEnd = false;


### PR DESCRIPTION
The handling of `}` as an input in `Factory::readObject` was causing a bug when combined with our new `Factory::readObjectOptional` method. Specifically, if the optional block read by `readObjectOptional` is the last block of its enclosing block, then `readObjectOptional` will read an input of `}` from the enclosing block, and this was being interpreted as a successful read. `Label::buffer` was cleared, and other classes were not able to read the `}` that they needed. 

To fix this, we make a small change to the handling of the Label static members when `Factory::readObject` reads `}` from the param file. 

1. If `isRequired == true`: return null pointer, clear the Label, set isEnd = true. The class that calls readObject needs to do its own handling of the null pointer. This is the same behavior as older versions of Util.
2. If `isRequired == false`: return null pointer, *don’t* clear the Label, set isEnd = true. If, for whatever reason, the class that calls readObjectOptional was expecting a “}”, then it can clear the Label itself with the new Label methods that we added, although it doesn't seem that any class will use it this way. Otherwise, the Label will still contain the “}” so that it can be read by something else. 

The only case in which a `}` is intentionally read by a Factory is during the construction of a Manager. The `Manager::readParam` method calls `Factory::readObject` with `isRequired = true`, and should never need to read a block with `isRequired = false` (the Manager class itself will throw an error if Factory returns a null pointer and `isEnd == false`). As such, `Factory::readObject` behaves the same as it did before from the perspective of the Manager class, and the handling of `}` should thus be correct for all of the relevant circumstances. Furthermore, the Manager unit tests check to make sure that `Manager::readParam` works correctly, by reading multiple example Manager objects and ensuring that the subclasses within Manager are correct.

All unit tests for Util, as well as the devel branch of pscfpp (excluding GPU unit tests), pass after implementing this update. Examples have been run to ensure that the bug does not persist.